### PR TITLE
fix: update broken logo and favicon URLs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # SHiP Software
 
-[![SHiP logo](https://ship.web.cern.ch/sites/default/files/SHIP_logo.png)](https://ship.web.cern.ch/)
+[![SHiP logo](https://ship.web.cern.ch/wp-content/uploads/2025/08/SHiP-Full_Black.png)](https://ship.web.cern.ch/)
 
 Welcome to the documentation for the [SHiP experiment](https://ship.web.cern.ch/) software.
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -23,8 +23,8 @@ nav = [
 
 [project.theme]
 variant = "classic"
-logo = "https://ship.web.cern.ch/sites/default/files/SHIP_logo.png"
-favicon = "https://ship.web.cern.ch/sites/default/files/favicon.ico"
+logo = "https://ship.web.cern.ch/wp-content/uploads/2025/07/SHiP-Symbol_White_logo_webpage-1.png"
+favicon = "https://ship.web.cern.ch/wp-content/uploads/2025/08/115x115.png"
 language = "en"
 
 features = [


### PR DESCRIPTION
The SHiP website migrated to WordPress, breaking the old asset paths. Update to the new wp-content URLs.