### PR TITLE
fix: update indentation for numbering scheme to show correctly

### DIFF
--- a/docs/simulation/index.md
+++ b/docs/simulation/index.md
@@ -21,13 +21,15 @@ phlex -c $WORK_DIR/slc9_x86-64/aegir/latest/share/aegir/workflows/pythia8_mt.jso
 
 ## Three steps to target simulation
 1. Collide proton beam at 400 GeV on fixed protons and neutrons using Pythia8
-   - Beam travels in the z direction only, but smearing and painting are applied
-   - Random choice for beam to interact with protons or neutrons based on the Z/A of the material it traverses
+    - Beam travels in the z direction only, but smearing and painting are applied
+    - Random choice for beam to interact with protons or neutrons based on the Z/A of the material it traverses
 2. Transport particles with GEANT4 (and decay them, make them interact with matter, etc.)
-   - Interactions with matter is time-consuming bit of target simulation
-   -  To save time, particles below a certain energy are not transported
+    - Interactions with matter is time-consuming bit of target simulation
+    -  To save time, particles below a certain energy are not transported
 3. Save particles which reach a sensitive plane right after the hadron absorber (HA)
-   -  Only particle above a certain energy are saved
+    -  Only particle above a certain energy are saved
+
+<!-- -->
 
 This simulation contains only target complex and hadron absorber. The magnetic field is also turned off.
 


### PR DESCRIPTION
While the .md looks fine, bullet points (including sub-bullet points) are each given increasing numbers in the `index.md`. To try and mitigate this, 4 blank spaces are used before the sub-bullet points