### PR TITLE
docs: lead with pixi; corral aliBuild into legacy sections

### DIFF
--- a/docs/fairship/faq.md
+++ b/docs/fairship/faq.md
@@ -9,7 +9,16 @@ Linux is supported:
 
 Other distributions may be available upon sufficient interest.
 
-## aliBuild not using system/CVMFS packages
+## LHCb environment interference
+
+The `lbenv` tool can break the SHiP software stack. Configure `lbenv` to prevent automatic loading. With the right configuration, both LHCb and SHiP software can coexist in the same account.
+
+## Legacy aliBuild issues (CVMFS releases ≤26.04)
+
+These FAQs only apply to the legacy aliBuild path — see
+[Installation → Legacy releases](installation.md#legacy-releases-cvmfs--alibuild-2604).
+
+### aliBuild not using system/CVMFS packages
 
 Use the `--always-prefer-system` flag on platforms like RHEL9 where aliBuild does not automatically use system packages:
 
@@ -17,7 +26,7 @@ Use the `--always-prefer-system` flag on platforms like RHEL9 where aliBuild doe
 aliBuild build --always-prefer-system FairShip
 ```
 
-## Git "unsafe directory" warning
+### Git "unsafe directory" warning
 
 Recent versions of Git may refuse to operate in directories owned by other users. If you see this warning, add the directory to the safe list:
 
@@ -26,7 +35,3 @@ git config --global --add safe.directory /cvmfs/ship.cern.ch/24.01/shipdist
 ```
 
 This was resolved in aliBuild 1.17.3+.
-
-## LHCb environment interference
-
-The `lbenv` tool can break the SHiP software stack. Configure `lbenv` to prevent automatic loading. With the right configuration, both LHCb and SHiP software can coexist in the same account.

--- a/docs/fairship/index.md
+++ b/docs/fairship/index.md
@@ -14,6 +14,11 @@ Repository: [ShipSoft/FairShip](https://github.com/ShipSoft/FairShip)
 ## Quick start
 
 ```bash
-aliBuild build FairShip
-alienv enter FairShip/latest
+git clone https://github.com/ShipSoft/FairShip.git
+cd FairShip
+pixi run build
+pixi run python macro/run_simScript.py --tag my-simulation
 ```
+
+See [Installation](installation.md) for the full details, including the
+legacy CVMFS + aliBuild path for releases ≤26.04.

--- a/docs/fairship/installation.md
+++ b/docs/fairship/installation.md
@@ -1,10 +1,49 @@
 # Installation
 
-## Using AliBuild (recommended)
+## Using pixi (recommended)
+
+[Pixi](https://pixi.sh) manages all of FairShip's dependencies via the
+`pixi.toml` and `activate.sh` shipped in the FairShip clone. The
+activation script sets `FAIRSHIP`, `GEOMPATH`, and similar paths to the
+clone, so the pixi project root **must** be the FairShip clone itself.
+
+1. [Install pixi](https://pixi.sh/latest/#installation).
+2. Clone and build:
+    ```bash
+    git clone https://github.com/ShipSoft/FairShip.git
+    cd FairShip
+    pixi run build
+    ```
+3. Run commands inside the environment:
+    ```bash
+    pixi run python macro/run_simScript.py --tag my-simulation
+    ```
+   Or start a shell:
+    ```bash
+    pixi shell
+    python macro/run_simScript.py --tag my-simulation
+    ```
+
+Pre-built FairShip packages are also published to the
+[prefix.dev/ship](https://prefix.dev/channels/ship) channel; see the
+[FairShip README](https://github.com/ShipSoft/FairShip#using-pixi) for
+that flow.
+
+## Legacy releases (CVMFS + aliBuild, ≤26.04)
+
+These instructions are kept for users on existing CVMFS releases up to
+**26.04** and for legacy branches (`SHiP-2018`, `muflux`). New
+development uses pixi — see [Using pixi](#using-pixi-recommended)
+above and the [shipdist page](../shipdist/index.md).
+
+With CVMFS (e.g. lxplus):
 
 ```bash
-git clone https://github.com/alisw/alibuild.git
-export ALIBUILD_WORK_DIR=$HOME/ship/sw
-
-aliBuild build FairShip
+source /cvmfs/ship.cern.ch/$SHIP_RELEASE/setUp.sh
+aliBuild build FairShip --always-prefer-system --config-dir $SHIPDIST --defaults release
+alienv enter FairShip/latest
 ```
+
+Without CVMFS, install aliBuild via `pipx`/`pip`, clone
+[shipdist](https://github.com/ShipSoft/shipdist) alongside FairShip, and
+run `aliBuild build FairShip` with the same defaults.

--- a/docs/htcondor/index.md
+++ b/docs/htcondor/index.md
@@ -8,7 +8,9 @@ Repository: [ShipSoft/htcondor_submission_scripts](https://github.com/ShipSoft/h
 ## Quick start -- `run_fixedTarget.py` example with ganga
 You will need 2 files in order to run your script: `bashScript.sh` and `gangaScript.py`.
 
-Your `bashScript.sh` lays out what you want to run. For example, for `run_fixedTarget.py`, you would use something like the following (note that you could also use your own version of FairShip):
+Your `bashScript.sh` lays out what you want to run. The snippet below
+sources the CVMFS aliBuild release **26.04** as an example — substitute
+the release you want, or point at your own FairShip build instead.
 ```
 FS_INSTALL=/cvmfs/ship.cern.ch/26.04/
 export WORK_DIR=${FS_INSTALL}/sw/

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,6 @@ Welcome to the documentation for the [SHiP experiment](https://ship.web.cern.ch/
 - **[FairShip](fairship/index.md)** — Simulation and reconstruction framework
 - **[Simulation](simulation/index.md)** — Simulation framework
 - **[Geometry](geometry/index.md)** — Detector geometry description
-- **[shipdist](shipdist/index.md)** — Build recipes for the SHiP software stack
+- **[shipdist](shipdist/index.md)** — aliBuild recipes (CVMFS releases); new development uses [ship-conda-recipes](https://github.com/ShipSoft/ship-conda-recipes) and pixi
 - **[cvmfs_release](cvmfs-release/index.md)** — CVMFS release management
 - **[HTCondor](htcondor/index.md)** — Job submission scripts for the HTCondor batch system

--- a/docs/shipdist/index.md
+++ b/docs/shipdist/index.md
@@ -1,5 +1,17 @@
 # shipdist
 
-Build recipes ([aliBuild](https://alisw.github.io/alibuild/) packages) for the SHiP software stack.
+`shipdist` holds the [aliBuild](https://alisw.github.io/alibuild/)
+recipes for the SHiP software stack — the build system behind the
+CVMFS releases under `/cvmfs/ship.cern.ch/`.
+
+New development uses pixi and the conda-forge ecosystem instead:
+
+- [FairShip — Using pixi](../fairship/index.md)
+- [ship-conda-recipes](https://github.com/ShipSoft/ship-conda-recipes)
+  — rattler-build recipes for the SHiP-specific packages, published to
+  the [prefix.dev/ship](https://prefix.dev/channels/ship) channel.
+
+For users on existing CVMFS releases, see
+[FairShip → Legacy releases](../fairship/installation.md#legacy-releases-cvmfs--alibuild-2604).
 
 Repository: [ShipSoft/shipdist](https://github.com/ShipSoft/shipdist)

--- a/docs/simulation/index.md
+++ b/docs/simulation/index.md
@@ -9,15 +9,18 @@ It is based on:
 - [Geant4](https://geant4.web.cern.ch/)
 - [Pythia8](https://pythia.org/)
 
-Repository: [ShipSoft/Aegir](https://github.com/ShipSoft/aegir)
+Repository: [ShipSoft/aegir](https://github.com/ShipSoft/aegir)
 
 ## Quick start
 
+```bash
+git clone https://github.com/ShipSoft/aegir.git
+cd aegir
+pixi run build
+pixi run phlex -c workflows/pythia8_mt.jsonnet
 ```
-export WORK_DIR=/cvmfs/ship-nightlies.cern.ch/next/sw/
-source $WORK_DIR/slc9_x86-64/aegir/latest/etc/profile.d/init.sh
-phlex -c $WORK_DIR/slc9_x86-64/aegir/latest/share/aegir/workflows/pythia8_mt.jsonnet
-```
+
+See [Installation](installation.md) for details.
 
 ## Three steps to target simulation
 1. Collide proton beam at 400 GeV on fixed protons and neutrons using Pythia8

--- a/docs/simulation/installation.md
+++ b/docs/simulation/installation.md
@@ -1,15 +1,33 @@
 # Installation
 
-Depending on use cases, you might or might not need to build Aegir. For use cases such as updating `.jsonnet` files, it is sufficient to source the latest `ship-nightlies`.
+Aegir is built with [pixi](https://pixi.sh). Two use cases:
 
-```
-export WORK_DIR=/cvmfs/ship-nightlies.cern.ch/next/sw/
-source $WORK_DIR/slc9_x86-64/aegir/latest/etc/profile.d/init.sh
+## Just running the framework
+
+If you only need to run workflows (e.g. update `.jsonnet` files, drive
+existing simulations), consume the pre-built `aegir` package from the
+[prefix.dev/ship](https://prefix.dev/channels/ship) channel:
+
+```bash
+pixi init my-aegir-workspace
+cd my-aegir-workspace
+pixi project channel add https://prefix.dev/ship
+pixi add aegir
+pixi run phlex -c <path-to-workflow>.jsonnet
 ```
 
-For more involved use cases, such as changing the source code, you also need to build your local version of Aegir. Currently aliBuild is recommended:
+## Building from source
 
+For changes to the C++ code, clone and build:
+
+```bash
+git clone https://github.com/ShipSoft/aegir.git
+cd aegir
+pixi run build
 ```
-source $WORK_DIR/slc9_x86-64/alibuild/latest/etc/profile.d/init.sh
-aliBuild build aegir --always-prefer-system -c /cvmfs/ship-nightlies.cern.ch/next/shipdist --defaults release
-```
+
+`pixi run build` depends on `configure`, so a fresh checkout becomes a
+ready-to-run environment in one command. See the
+[aegir README](https://github.com/ShipSoft/aegir#building-with-pixi-recommended)
+for the full list of tasks (`test`, `smoke`, `clean`, …) and the
+`pixi shell` vs `pixi run` workflow.

--- a/docs/simulation/running.md
+++ b/docs/simulation/running.md
@@ -1,18 +1,32 @@
 # Running
 
-For a series of use cases (eg. updating `.jsonnet` files), it is not needed to build Aegir. Instead, if you have your local version of Aegir, you can simply execute the following commands
+If you have an aegir clone built with pixi, run any workflow with:
 
+```bash
+pixi run phlex -c workflows/fixed_target_mt.jsonnet
 ```
-export WORK_DIR=/cvmfs/ship-nightlies.cern.ch/next/sw/
-source $WORK_DIR/slc9_x86-64/aegir/latest/etc/profile.d/init.sh
+
+Or drop into a pixi shell first for an interactive session:
+
+```bash
+pixi shell
 phlex -c workflows/fixed_target_mt.jsonnet
 ```
 
-If you need to change the source code, remember to build Aegir.
+`activate.sh` sets `PHLEX_PLUGIN_PATH`, `LD_LIBRARY_PATH`,
+`SHIPGEOMETRY_ROOT`, and `AEGIR_ROOT` automatically in both modes — no
+manual prefix needed.
 
-Information regarding the simulation to generate is located in the `.jsonnet` files. A few examples are in the `workflow` folder.
+If you do not need to modify the source, you can also consume the
+pre-built `aegir` package from the
+[prefix.dev/ship](https://prefix.dev/channels/ship) channel — see
+[Installation](installation.md) for that flow.
 
-You can choose to use `geometry_geomodel_provider` or `geometry_gdml_provider` for the geometry: 
+Information regarding the simulation to generate is located in the
+`.jsonnet` files. A few examples are in the `workflows/` folder.
+
+You can choose to use `geometry_geomodel_provider` or
+`geometry_gdml_provider` for the geometry:
 
 ```
 geometry: {


### PR DESCRIPTION
## Summary

Aligns the SHiP Core Software documentation with the migration to pixi
+ conda-forge. Pixi is presented as the supported build/run path
everywhere; the remaining aliBuild / CVMFS content lives in
explicitly-labelled legacy sections or is annotated as illustrative.

### Per-page changes

- **\`docs/fairship/index.md\`** — quick start uses \`pixi run\`.
- **\`docs/fairship/installation.md\`** — "Using pixi (recommended)" is the
  primary section; aliBuild instructions move under "Legacy releases
  (CVMFS + aliBuild, ≤26.04)".
- **\`docs/fairship/faq.md\`** — aliBuild-specific FAQs grouped under
  "Legacy aliBuild issues".
- **\`docs/simulation/{index,installation,running}.md\`** — pixi-first
  rewrite (clone + \`pixi run build\`, or \`pixi add aegir\` from the
  prefix.dev/ship channel).
- **\`docs/shipdist/index.md\`** — framed as "aliBuild recipes for CVMFS
  releases; new development uses ship-conda-recipes and pixi". No
  unmaintained claim — that comes when the repo is actually archived.
- **\`docs/htcondor/index.md\`** — example annotated as illustrative ("…
  CVMFS aliBuild release 26.04 as an example — substitute the release
  you want").
- **\`docs/index.md\`** — shipdist entry reframed similarly.

### Intentionally left alone

- **\`docs/fairship/samples.md\`** — the FairShip 25.12 / 26.03 / 26.04
  references are factual provenance metadata about the existing
  sample files, not build instructions.

## Test plan

- [x] \`rg 'aliBuild|alienv|shipdist|/cvmfs/ship'\` returns hits only
      under labelled legacy sections, the shipdist landing page,
      samples.md (factual provenance), and the htcondor example
      preamble.
- [ ] Site builds via Zensical without broken links.