### PR TITLE
docs(packaging): add maintainer guide for the conda packaging stack

### DIFF
--- a/docs/packaging/add-a-recipe.md
+++ b/docs/packaging/add-a-recipe.md
@@ -1,0 +1,63 @@
+# Add a new recipe
+
+1. Pick a sibling recipe with a similar shape (CMake project? Header-only? Python package?) and copy its directory:
+
+    ```bash
+    cp -r recipes/random123 recipes/<new-pkg>
+    ```
+
+2. Edit `recipes/<new-pkg>/recipe.yaml`:
+   - `context.version` — current upstream release.
+   - `source.url` — tarball URL (GitHub `archive/refs/tags/`, GitLab
+     CERN `archive`, etc.). Use the same template variables as the
+     surrounding recipes so [Renovate](bump-a-version.md) can update
+     it automatically.
+   - `source.sha256` — `curl -fsSL <url> | sha256sum`.
+   - `requirements.{build,host,run}` — declare every sibling recipe
+     this package depends on by name. rattler-build resolves the
+     build order from these lists, so this is the **only** place to
+     express ordering.
+   - `tests:` — at minimum a `package_contents:` block listing the
+     headers / libs / CMake configs the build is expected to produce.
+     For runtime-executable packages add a `script:` test that runs
+     a Python import or `root -l -q` invocation.
+   - `about:` — populate `homepage`, `repository`, `summary`,
+     `description`, `license` (SPDX), `license_file`.
+   - `extra.recipe-maintainers:` — your GitHub handle, plus at least
+     one co-maintainer where possible.
+
+3. Adjust `recipes/<new-pkg>/build.sh` for the build system in use.
+
+4. From the repo root, dry-run the build locally:
+
+    ```bash
+    pixi run rattler-build build --recipe recipes/<new-pkg> \
+        --channel https://prefix.dev/ship --channel conda-forge
+    ```
+
+5. Open a PR. CI runs `pixi run build-all`
+   (`rattler-build build --recipe-dir recipes/ --skip-existing=all`),
+   which rebuilds every recipe whose dependencies changed. Uploads to
+   `prefix.dev/ship` are gated on push to `main`.
+
+6. After merge, decide whether the recipe is an
+   [upstream candidate](https://github.com/ShipSoft/ship-conda-recipes/blob/main/README.md#packages)
+   and update the table.
+
+## Notes
+
+- Recipe directory name **must** equal the `package.name` in
+  `recipe.yaml`. rattler-build's cross-recipe dependency resolution
+  keys off the name in `requirements:`.
+- Don't add the recipe to a separate manifest file — there isn't
+  one. The `requirements:` block is the single source of truth for
+  dependency order.
+- For a single-recipe local iteration, run the inline form:
+
+    ```bash
+    pixi run rattler-build build --recipe recipes/<new-pkg> \
+        --channel https://prefix.dev/ship --channel conda-forge
+    ```
+
+  or, for the recipe currently most under churn, the `build-<name>`
+  pixi task shortcut.

--- a/docs/packaging/bump-a-version.md
+++ b/docs/packaging/bump-a-version.md
@@ -1,0 +1,63 @@
+# Bump a package version
+
+Most recipes track upstream tags via
+[Renovate](https://github.com/ShipSoft/ship-conda-recipes/blob/main/renovate.json).
+A weekend cron opens a PR per upstream release; review the diff,
+merge if CI is green, and the new build flows to `prefix.dev/ship`.
+
+## Renovate-managed recipes
+
+The `customManagers` in `renovate.json` cover three patterns:
+
+- GitHub tags via `archive/refs/tags/v<X>.tar.gz` URLs.
+- GitHub tags via templated `context.version` + `archive/` URLs.
+- GitLab CERN tags via templated `context.version` +
+  `archive/` URLs.
+
+If you copy a sibling recipe ([Add a new recipe](add-a-recipe.md))
+its source URL will already match one of these patterns and Renovate
+will pick it up automatically.
+
+When Renovate opens a PR, check that:
+
+- `build.number` was reset to `0`. Renovate doesn't reset it; you
+  may need to edit the PR.
+- `source.sha256` was bumped. Renovate doesn't refresh hashes for
+  every pattern; if the PR fails to build with a hash mismatch,
+  copy the expected SHA from the rattler-build error and push it.
+
+## Branch-pinned recipes (manual)
+
+A few recipes pin a branch or commit instead of a release tag.
+These are disabled in `renovate.json`:
+
+- `SHiP/FairShip`
+- `ShipSoft/data-model`
+- `ShipSoft/geometry_service`
+- `SND-LHC/pythia6`
+- `luketpickering/ROOTEGPythia6`
+
+To bump one:
+
+1. Edit `recipes/<pkg>/recipe.yaml`:
+   - `context.version` — the new short SHA or branch name.
+   - `source.url` — point at the new commit (`archive/<sha>.tar.gz`).
+   - `source.sha256` — recompute.
+2. Bump `build.number` if the upstream change doesn't change the
+   version string but should produce a fresh package.
+3. Open a PR.
+
+## ABI rebuilds across the channel
+
+When an ABI break lands in an upstream conda-forge package
+(`root` major version, `geant4` major version, `libstdcxx`, etc.):
+
+1. Bump `build.number` on every recipe that links the affected
+   library. The current build numbers serve as the rebuild signal.
+2. Trigger `workflow_dispatch` on `build.yml`. The
+   `--skip-existing=all` flag will pick up the bumped build numbers
+   as new packages to build and skip the rest.
+
+For a smaller, targeted rebuild of a single recipe, use the
+`recipe` and `force` inputs to `workflow_dispatch` (see
+[CI workflows and secrets](ci-and-secrets.md)).

--- a/docs/packaging/ci-and-secrets.md
+++ b/docs/packaging/ci-and-secrets.md
@@ -1,0 +1,78 @@
+# CI workflows and secrets
+
+## Workflows in `ship-conda-recipes`
+
+### `build.yml` — build and upload
+
+Triggers on push to `main`, pull requests against `main`, and
+`workflow_dispatch`. The whole channel is built with one command:
+
+```bash
+pixi run rattler-build build \
+    --recipe-dir recipes/ \
+    --channel https://prefix.dev/ship \
+    --channel conda-forge \
+    --skip-existing=all
+```
+
+rattler-build resolves cross-recipe dependency order from the
+`requirements:` blocks; nothing else needs maintaining. On push to
+`main`, every `output/{linux-64,noarch}/*.conda` artifact is
+uploaded with `rattler-build upload prefix -c ship --skip-existing`.
+
+PR builds run the same build step but **do not** upload.
+
+### `update-lock-files.yml` — monthly pixi lock refresh
+
+Calls the reusable
+[`ShipSoft/.github/.github/workflows/pixi-lock-update.yml@main`](https://github.com/ShipSoft/.github/blob/main/.github/workflows/pixi-lock-update.yml).
+Runs on the 1st of each month at 05:00 UTC and opens an
+`update-pixi` PR with the `pixi update` diff.
+
+### `channel-snapshot.yml` — weekly channel inventory
+
+Mondays at 06:00 UTC. Fetches
+`https://prefix.dev/ship/{linux-64,noarch}/repodata.json`,
+renders `channel-snapshot.md`, and opens (or updates) a
+`channel-snapshot` PR if the contents changed. The diff is the
+changelog.
+
+## Secrets
+
+- `PREFIX_DEV_API_KEY` — organisation secret. Used by
+  `rattler-build upload prefix` in `build.yml` on push to `main`.
+  Provisioned in ShipSoft GitHub org → Settings → Secrets and
+  variables → Actions. Rotated from prefix.dev account settings.
+- `GITHUB_TOKEN` — default per-run token; sufficient for the
+  `peter-evans/create-pull-request` calls in
+  `update-lock-files.yml` and `channel-snapshot.yml`. No extra
+  configuration needed.
+
+## Triggering a targeted rebuild
+
+From the GitHub Actions UI, run `Build and upload conda packages`
+with `workflow_dispatch`. Two inputs help when only one recipe
+needs to be rebuilt (e.g. after Renovate bumps a single upstream
+version):
+
+- `recipe` — directory name under `recipes/`, e.g. `random123`.
+  Restricts the build to that recipe; its dependencies are pulled
+  from the channel.
+- `force` — drops `--skip-existing` so a rebuild proceeds even
+  when an artifact with the same build number is already on the
+  channel. Pair with a `build.number` bump in the recipe.
+
+## Reusable workflows
+
+The cross-repo CI pieces live in
+[`ShipSoft/.github`](https://github.com/ShipSoft/.github/tree/main/.github/workflows):
+
+- `pixi-lock-update.yml` — monthly lock-file PR (used by
+  `ship-conda-recipes`, `aegir`, `FairShip`).
+- `pixi-cmake-build.yml` — generic pixi-driven CMake build with
+  a JSON task array (used by `aegir`, `geometry`,
+  `geometry_service`).
+- `doxygen-gh-pages.yml` — Doxygen build + Pages deploy.
+
+When adding a new ShipSoft repo, prefer calling one of these
+rather than inlining the same setup-pixi boilerplate.

--- a/docs/packaging/index.md
+++ b/docs/packaging/index.md
@@ -1,0 +1,55 @@
+# Packaging
+
+SHiP distributes its software stack as conda packages on the
+[`prefix.dev/ship`](https://prefix.dev/channels/ship) channel. Packages
+that aren't on conda-forge are built from recipes in
+[`ShipSoft/ship-conda-recipes`](https://github.com/ShipSoft/ship-conda-recipes);
+everything else is pulled directly from
+[conda-forge](https://conda-forge.org).
+
+Downstream repos (`FairShip`, `aegir`, `geometry`, `geometry_service`)
+consume the channel via their `pixi.toml`:
+
+```toml
+channels = ["https://prefix.dev/ship", "conda-forge"]
+```
+
+## Flow
+
+```
+upstream sources (GitHub / GitLab CERN tags)
+        │
+        ▼
+ship-conda-recipes/recipes/<pkg>/recipe.yaml
+        │   rattler-build build --recipe-dir recipes/
+        ▼
+ship-conda-recipes/output/{linux-64,noarch}/*.conda
+        │   rattler-build upload prefix -c ship
+        ▼
+prefix.dev/ship channel
+        │
+        ▼
+downstream repo's pixi.toml  →  developer / CI environment
+```
+
+## Maintainer tasks
+
+- [Add a new recipe](add-a-recipe.md)
+- [Bump a package version](bump-a-version.md)
+- [CI workflows and secrets](ci-and-secrets.md)
+
+## Channel snapshot
+
+A weekly job in `ship-conda-recipes` writes the current channel
+contents to
+[`channel-snapshot.md`](https://github.com/ShipSoft/ship-conda-recipes/blob/main/channel-snapshot.md).
+The diff between snapshots doubles as a changelog and surfaces
+accidental publishes.
+
+## Scope
+
+`ship-conda-recipes` hosts only packages that aren't (yet) on
+conda-forge. When an upstream candidate lands on conda-forge, the
+local recipe is dropped — see for example
+[ShipSoft/ship-conda-recipes#23](https://github.com/ShipSoft/ship-conda-recipes/commit/e0b730cf6)
+for the `faircmakemodules` migration.

--- a/zensical.toml
+++ b/zensical.toml
@@ -24,6 +24,12 @@ nav = [
     { "FAQ" = "simulation/faq.md" },
   ] },
   { "Geometry" = "geometry/index.md" },
+  { "Packaging" = [
+    { "Overview" = "packaging/index.md" },
+    { "Add a recipe" = "packaging/add-a-recipe.md" },
+    { "Bump a version" = "packaging/bump-a-version.md" },
+    { "CI and secrets" = "packaging/ci-and-secrets.md" },
+  ] },
   { "shipdist" = "shipdist/index.md" },
   { "cvmfs_release" = "cvmfs-release/index.md" },
   { "HTCondor" = "htcondor/index.md" },


### PR DESCRIPTION
## Summary

Plan item 7 — new \`docs/packaging/\` section aimed at maintainers of \`ship-conda-recipes\`, not end users. Four pages:

- \`index.md\` — stack diagram (sources → ship-conda-recipes → prefix.dev/ship → pixi.toml → developer / CI) and pointers to the task pages.
- \`add-a-recipe.md\` — copy-a-sibling recipe authoring flow; emphasises that \`requirements:\` is the single source of truth for build order (rattler-build resolves it via \`--recipe-dir\`).
- \`bump-a-version.md\` — how Renovate handles tagged sources and the manual flow for branch-pinned packages (FairShip, data-model, geometry_service, pythia6, ROOTEGPythia6); ABI-rebuild flow.
- \`ci-and-secrets.md\` — covers \`build.yml\`, \`update-lock-files.yml\` and \`channel-snapshot.yml\`; lists secrets and reusable workflows in \`ShipSoft/.github\`.

\`zensical.toml\` nav gains a top-level "Packaging" section.

## Test plan

- [ ] Local Zensical preview renders all four pages and the nav entry.
- [ ] Cross-links resolve.